### PR TITLE
allow for optgroups in SelectControl

### DIFF
--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -188,8 +188,8 @@ If this property is added, multiple values can be selected. The value passed sho
 #### options
 
 An array of objects containing the following properties:
-- `label`: (string) The label to be shown to the user.
-- `value`: (Object) The internal value used to choose the selected value. This is also the value passed to onChange when the option is selected.
+- `label`: (string) The label to be shown to the user. (If the `value` property contains an array rather than a scalar, this will be the label for the option group.)
+- `value`: (Object) The internal value used to choose the selected value. This is also the value passed to onChange when the option is selected. If this is an array rather than a scalar, an option group will be created with the options contained in the array.
 - `disabled`: (boolean) Whether or not the option should have the disabled attribute.
 - Type: `Array`
 - Required: No

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -64,6 +64,7 @@ Position the label centered over the select, or right aligned against the side o
 - Menu items should be short — ideally, single words — and use sentence capitalization.
 - Do not use full sentences inside menu items.
 - Ensure that menu items are ordered in a way that is most useful to users. Alphabetical or recency ordering is preferred.
+- Menu items can optionally be grouped into option groups if this results in a more understandable presentation of options.
 
 ![](https://wordpress.org/gutenberg/files/2018/12/select-do-options.png)
 
@@ -114,6 +115,35 @@ Render a user interface to select multiple users from a list.
         { value: 'a', label: 'User A' },
         { value: 'b', label: 'User B' },
         { value: 'c', label: 'User c' },
+    ] }
+/>
+```
+
+Render a user interface to select users from a list grouped by role.
+
+```jsx
+<SelectControl
+    multiple
+    label={ __( 'Select some users:' ) }
+    value={ this.state.users } // e.g: value = [ 'a', 'c' ]
+    onChange={ ( users ) => { this.setState( { users } ) } }
+    options={ [
+        { label: 'Select a User', value: null, disabled: true },
+        { label: 'Admins', value: [
+			{ label: 'User A', value: 'a' },
+			{ label: 'User B', value: 'b' },
+			{ label: 'User C', value: 'c' },
+		] },
+        { label: 'Editors', value: [
+			{ label: 'User D', value: 'd' },
+			{ label: 'User E', value: 'e' },
+			{ label: 'User F', value: 'f' },
+		] },
+        { label: 'Subscribers', value: [
+			{ label: 'User G', value: 'g' },
+			{ label: 'User H', value: 'h' },
+			{ label: 'User I', value: 'i' },
+		] }
     ] }
 />
 ```

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -110,19 +110,51 @@ function SelectControl(
 					value={ valueProp }
 				>
 					{ options.map( ( option, index ) => {
-						const key =
-							option.id ||
-							`${ option.label }-${ option.value }-${ index }`;
+						if(Array.isArray(option.value)){
+							const key =
+								option.id ||
+								`${ option.label }-${ index }`;
+						} else {
+							const key =
+								option.id ||
+								`${ option.label }-${ option.value }-${ index }`;
+						}
 
-						return (
-							<option
-								key={ key }
-								value={ option.value }
-								disabled={ option.disabled }
-							>
-								{ option.label }
-							</option>
-						);
+						//if the option.value is an array rather than a scalar, we're dealing with an optgroup
+						if(Array.isArray(option.value)){
+							return (
+								<optgroup 
+									key={ key }
+									label={ option.label }
+								>
+									{ option.value.map( ( groupedOption, groupedOptionIndex ) => {
+										const key =
+											groupOption.id ||
+											`${ groupedOption.label }-${ groupedOption.value }-${ groupedOptionIndex }`;
+
+										return (
+											<option
+												key={ key }
+												value={ groupedOption.value }
+												disabled={ groupedOption.disabled }
+											>
+												{ groupedOption.label }
+											</option>
+										);
+									} ) }
+								</optgroup>
+							);
+						} else {
+							return (
+								<option
+									key={ key }
+									value={ option.value }
+									disabled={ option.disabled }
+								>
+									{ option.label }
+								</option>
+							);
+						}
 					} ) }
 				</Select>
 			</InputBase>

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -110,21 +110,15 @@ function SelectControl(
 					value={ valueProp }
 				>
 					{ options.map( ( option, index ) => {
-						if(Array.isArray(option.value)){
-							const key =
-								option.id ||
-								`${ option.label }-${ index }`;
-						} else {
-							const key =
-								option.id ||
-								`${ option.label }-${ option.value }-${ index }`;
-						}
 
 						//if the option.value is an array rather than a scalar, we're dealing with an optgroup
 						if(Array.isArray(option.value)){
+							const optgroupkey =
+								option.id ||
+								`${ option.label }-${ index }`;
 							return (
 								<optgroup 
-									key={ key }
+									key={ optgroupkey }
 									label={ option.label }
 									disabled={ option.disabled }
 								>
@@ -146,6 +140,9 @@ function SelectControl(
 								</optgroup>
 							);
 						} else {
+							const key =
+								option.id ||
+								`${ option.label }-${ option.value }-${ index }`;
 							return (
 								<option
 									key={ key }

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -129,7 +129,7 @@ function SelectControl(
 								>
 									{ option.value.map( ( groupedOption, groupedOptionIndex ) => {
 										const key =
-											groupOption.id ||
+											groupedOption.id ||
 											`${ groupedOption.label }-${ groupedOption.value }-${ groupedOptionIndex }`;
 
 										return (

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -126,6 +126,7 @@ function SelectControl(
 								<optgroup 
 									key={ key }
 									label={ option.label }
+									disabled={ option.disabled }
 								>
 									{ option.value.map( ( groupedOption, groupedOptionIndex ) => {
 										const key =

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -110,14 +110,13 @@ function SelectControl(
 					value={ valueProp }
 				>
 					{ options.map( ( option, index ) => {
-
 						//if the option.value is an array rather than a scalar, we're dealing with an optgroup
-						if(Array.isArray(option.value)){
+						if ( Array.isArray( option.value ) ) {
 							const optgroupkey =
 								option.id ||
 								`${ option.label }-${ index }`;
 							return (
-								<optgroup 
+								<optgroup
 									key={ optgroupkey }
 									label={ option.label }
 									disabled={ option.disabled }
@@ -126,7 +125,6 @@ function SelectControl(
 										const key =
 											groupedOption.id ||
 											`${ groupedOption.label }-${ groupedOption.value }-${ groupedOptionIndex }`;
-
 										return (
 											<option
 												key={ key }

--- a/packages/components/src/select-control/stories/index.js
+++ b/packages/components/src/select-control/stories/index.js
@@ -52,7 +52,7 @@ export const _default = () => {
 			{ value: 'b', label: 'Option B' },
 			{ value: 'c', label: 'Option C' },
 			{ value: [ { value: 'd', label: 'Option D'}, { value: 'e', label: 'Option E' } ], label: 'Group A' },
-			{ value: [ { value: 'f', label: 'Option F'}, { value: 'f', label: 'Option F' } ], label: 'Group B' },
+			{ value: [ { value: 'f', label: 'Option F'}, { value: 'g', label: 'Option G' } ], label: 'Group B' },
 		] ),
 		size: select(
 			'size',

--- a/packages/components/src/select-control/stories/index.js
+++ b/packages/components/src/select-control/stories/index.js
@@ -51,6 +51,8 @@ export const _default = () => {
 			{ value: 'a', label: 'Option A' },
 			{ value: 'b', label: 'Option B' },
 			{ value: 'c', label: 'Option C' },
+			{ value: [ { value: 'd', label: 'Option D'}, { value: 'e', label: 'Option E' } ], label: 'Group A' },
+			{ value: [ { value: 'f', label: 'Option F'}, { value: 'f', label: 'Option F' } ], label: 'Group B' },
 		] ),
 		size: select(
 			'size',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
Added the possibility of using optgroups in SelectControl components, as are allowed in html select inputs.

## How has this been tested?
The changes have not been tested.

## Screenshots <!-- if applicable -->


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
